### PR TITLE
Allow to "upsert" services/plugins resources.

### DIFF
--- a/kong/provider.go
+++ b/kong/provider.go
@@ -12,6 +12,7 @@ type config struct {
 	adminClient           *gokong.KongAdminClient
 	strictPlugins         bool
 	strictConsumerPlugins bool
+	upsertResources       bool
 }
 
 func Provider() terraform.ResourceProvider {
@@ -60,6 +61,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: envDefaultFuncWithDefault("STRICT_PLUGINS_MATCH", "false"),
 				Description: "Should plugins `config_json` field strictly match plugin configuration",
 			},
+			"upsert_resources": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: envDefaultFuncWithDefault("KONG_UPSERT_RESOURCES", "false"),
+				Description: "Use existing resources if creation raises a unique constraint error",
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -100,7 +107,6 @@ func envDefaultFuncWithDefault(key string, defaultValue string) schema.SchemaDef
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
-
 	kongConfig := &gokong.Config{
 		HostAddress:        d.Get("kong_admin_uri").(string),
 		Username:           d.Get("kong_admin_username").(string),
@@ -111,8 +117,9 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	}
 
 	config := &config{
-		adminClient:   gokong.NewClient(kongConfig),
-		strictPlugins: d.Get("strict_plugins_match").(bool),
+		adminClient:     gokong.NewClient(kongConfig),
+		strictPlugins:   d.Get("strict_plugins_match").(bool),
+		upsertResources: d.Get("upsert_resources").(bool),
 	}
 
 	return config, nil

--- a/kong/provider_test.go
+++ b/kong/provider_test.go
@@ -38,8 +38,7 @@ func TestProvider_impl(t *testing.T) {
 func TestProvider_configure(t *testing.T) {
 
 	rc := terraform.NewResourceConfigRaw(map[string]interface{}{})
-	p := Provider()
-	err := p.Configure(rc)
+	err := testAccProvider.Configure(rc)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/kong/resource_kong_plugin.go
+++ b/kong/resource_kong_plugin.go
@@ -92,7 +92,6 @@ func resourceKongPluginCreate(d *schema.ResourceData, meta interface{}) error {
 
 			d.SetId(dbPlugin.Id)
 			return resourceKongPluginUpdate(d, meta)
-
 		}
 		return fmt.Errorf("failed to create kong plugin: %v error: %w", pluginRequest, err)
 	}
@@ -209,7 +208,7 @@ func pluginConfigJsonToString(data map[string]interface{}) string {
 func findPlugin(
 	pluginClient *gokong.PluginClient, name string, consumerId *gokong.Id, routeId *gokong.Id, serviceId *gokong.Id,
 ) (*gokong.Plugin, error) {
-	// size is just how many plugins per request (1000 is the max)
+	// Size is just how many plugins per request (1000 is the max)
 	// but List will fetch all the pages so all the plugins
 	dbPlugins, err := pluginClient.List(&gokong.PluginQueryString{Size: 1000})
 	if err != nil {

--- a/kong/resource_kong_plugin.go
+++ b/kong/resource_kong_plugin.go
@@ -3,6 +3,7 @@ package kong
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/kevholditch/gokong"
@@ -71,16 +72,29 @@ func resourceKongPlugin() *schema.Resource {
 }
 
 func resourceKongPluginCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config)
+	pluginClient := config.adminClient.Plugins()
 
 	pluginRequest, err := createKongPluginRequestFromResourceData(d)
 	if err != nil {
 		return err
 	}
 
-	plugin, err := meta.(*config).adminClient.Plugins().Create(pluginRequest)
-
+	plugin, err := pluginClient.Create(pluginRequest)
 	if err != nil {
-		return fmt.Errorf("failed to create kong plugin: %v error: %v", pluginRequest, err)
+		if config.upsertResources && strings.Contains(err.Error(), "unique constraint violation") {
+			dbPlugin, err := findPlugin(
+				pluginClient, pluginRequest.Name, pluginRequest.ConsumerId, pluginRequest.RouteId, pluginRequest.ServiceId,
+			)
+			if err != nil {
+				return err
+			}
+
+			d.SetId(dbPlugin.Id)
+			return resourceKongPluginUpdate(d, meta)
+
+		}
+		return fmt.Errorf("failed to create kong plugin: %v error: %w", pluginRequest, err)
 	}
 
 	d.SetId(plugin.Id)
@@ -190,4 +204,24 @@ func pluginConfigJsonToString(data map[string]interface{}) string {
 	rawJson, _ := json.Marshal(marshalledData)
 
 	return string(rawJson)
+}
+
+func findPlugin(
+	pluginClient *gokong.PluginClient, name string, consumerId *gokong.Id, routeId *gokong.Id, serviceId *gokong.Id,
+) (*gokong.Plugin, error) {
+	// size is just how many plugins per request (1000 is the max)
+	// but List will fetch all the pages so all the plugins
+	dbPlugins, err := pluginClient.List(&gokong.PluginQueryString{Size: 1000})
+	if err != nil {
+		return nil, fmt.Errorf("could not read existing plugins: %w", err)
+	}
+	for _, p := range dbPlugins {
+		if p.Name == name &&
+			gokong.IdToString(p.ConsumerId) == gokong.IdToString(consumerId) &&
+			gokong.IdToString(p.RouteId) == gokong.IdToString(routeId) &&
+			gokong.IdToString(p.ServiceId) == gokong.IdToString(serviceId) {
+			return p, nil
+		}
+	}
+	return nil, fmt.Errorf("could not find plugin with name %s", name)
 }

--- a/kong/resource_kong_plugin_test.go
+++ b/kong/resource_kong_plugin_test.go
@@ -162,12 +162,14 @@ func TestAccKongPluginImportConfigJson(t *testing.T) {
 }
 
 func TestAccKongPlugin_Upsert(t *testing.T) {
-
-	uniqueConstraintError, _ := regexp.Compile(".*unique constraint violation.*")
+	uniqueConstraintError, err := regexp.Compile(".*unique constraint violation.*")
+	if err != nil {
+		t.Fatalf("could not compile regex: %v", err)
+	}
 
 	TestProvider_configure(t)
 
-	os.Unsetenv("KONG_UPSERT_RESOURCES")
+	// We'll manipulate this variable during the test, unset it at the end
 	defer os.Unsetenv("KONG_UPSERT_RESOURCES")
 
 	// Simulate that plugin already exists but with different values.
@@ -201,17 +203,21 @@ EOT
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			// With upsert disable (default value), this will raise a unique constraint error.
+			// With upsert disable (default value), this will raise an unique constraint error.
 			{
+				PreConfig: func() {
+					if err := os.Unsetenv("KONG_UPSERT_RESOURCES"); err != nil {
+						t.Fatalf("could not unset environment variable KONG_UPSERT_RESOURCES: %v", err)
+					}
+				},
 				Config:      pluginConf,
 				ExpectError: uniqueConstraintError,
 			},
-			// enable upsert, this should update the existing
+			// Enable upsert, this should update the existing
 			{
 				PreConfig: func() {
-					err := os.Setenv("KONG_UPSERT_RESOURCES", "true")
-					if err != nil {
-						t.Fatalf("Could not set KONG_UPSERT_RESOURCES env variable: %v", err)
+					if err := os.Setenv("KONG_UPSERT_RESOURCES", "true"); err != nil {
+						t.Fatalf("could not set KONG_UPSERT_RESOURCES env variable: %v", err)
 					}
 				},
 				Config: pluginConf,

--- a/kong/resource_kong_service_test.go
+++ b/kong/resource_kong_service_test.go
@@ -2,10 +2,13 @@ package kong
 
 import (
 	"fmt"
+	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/kevholditch/gokong"
 )
 
 func TestAccKongService(t *testing.T) {
@@ -81,6 +84,61 @@ func TestAccKongServiceImport(t *testing.T) {
 				ResourceName:      "kong_service.service",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccKongService_Upsert(t *testing.T) {
+
+	uniqueConstraintError, _ := regexp.Compile(".*unique constraint violation.*")
+
+	TestProvider_configure(t)
+
+	os.Unsetenv("KONG_UPSERT_RESOURCES")
+	defer os.Unsetenv("KONG_UPSERT_RESOURCES")
+
+	// Simulate that service with same name already exists but with different values.
+	request := &gokong.ServiceRequest{
+		Name:     gokong.String("test"),
+		Host:     gokong.String("foo.org"),
+		Protocol: gokong.String("https"),
+	}
+	service, err := testAccProvider.Meta().(*config).adminClient.Services().Create(request)
+	if err != nil {
+		t.Fatalf("could not create service test: %v", err)
+	}
+	expectedServiceID := *service.Id
+
+	serviceConf := `
+resource "kong_service" "service" {
+	name     = "test"
+	host     = "test.org"
+	protocol = "http"
+}`
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// With upsert disable (default value), this will raise a unique constraint error.
+			{
+				Config:      serviceConf,
+				ExpectError: uniqueConstraintError,
+			},
+			// enable upsert, this should update the existing
+			{
+				PreConfig: func() {
+					err := os.Setenv("KONG_UPSERT_RESOURCES", "true")
+					if err != nil {
+						t.Fatalf("Could not set KONG_UPSERT_RESOURCES env variable: %v", err)
+					}
+				},
+				Config: serviceConf,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKongServiceExists("kong_service.service"),
+					resource.TestCheckResourceAttr("kong_service.service", "id", expectedServiceID),
+					resource.TestCheckResourceAttr("kong_service.service", "host", "test.org"),
+					resource.TestCheckResourceAttr("kong_service.service", "protocol", "http"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
With this option enabled, if the resource creation raises a unique constraint error, the provider will update the existing one.